### PR TITLE
Feat/time deal review

### DIFF
--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/domain/RedisLock.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/domain/RedisLock.java
@@ -1,0 +1,41 @@
+package com.bjcareer.stockservice.timeDeal.domain;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RedisLock {
+    private final RedissonClient redissonClient;
+
+
+    public boolean tryLock(String lockName) {
+        log.debug("lock Name {} 획득 요청", lockName);
+        RLock lock = redissonClient.getLock(lockName);
+        boolean result = false;
+
+        try {
+            result = lock.tryLock(1, 1, TimeUnit.MINUTES);
+        } catch (InterruptedException e) {
+            log.error(e.getMessage());
+            throw new IllegalStateException("Lock 요청 실패");
+        }
+
+        log.debug("lock Name {} 획득 결과 {}", lockName, result);
+        return result;
+    }
+
+    public void releaselock(String lockName) {
+        log.debug("lock release {}", lockName);
+        RLock lock = redissonClient.getLock(lockName);
+        lock.unlock();
+    }
+
+
+}

--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/domain/RedisLock.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/domain/RedisLock.java
@@ -13,27 +13,27 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class RedisLock {
     private final RedissonClient redissonClient;
+    private final Long WAIT_TIME = 1L;
+    private final Long LEASE_TIME = 0L;
 
-
-    public boolean tryLock(String lockName) {
-        log.debug("lock Name {} 획득 요청", lockName);
-        RLock lock = redissonClient.getLock(lockName);
+    public boolean tryLock(String key) {
+        log.debug("lock Name {} 획득 요청", key);
+        RLock lock = redissonClient.getLock(key);
         boolean result = false;
 
         try {
-            result = lock.tryLock(1, 1, TimeUnit.MINUTES);
+            result = lock.tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.MINUTES);
         } catch (InterruptedException e) {
             log.error(e.getMessage());
-            throw new IllegalStateException("Lock 요청 실패");
         }
 
-        log.debug("lock Name {} 획득 결과 {}", lockName, result);
+        log.debug("lock Name {} 획득 결과 {}", key, result);
         return result;
     }
 
-    public void releaselock(String lockName) {
-        log.debug("lock release {}", lockName);
-        RLock lock = redissonClient.getLock(lockName);
+    public void releaselock(String key) {
+        log.debug("lock release {}", key);
+        RLock lock = redissonClient.getLock(key);
         lock.unlock();
     }
 

--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/domain/TimeDealEvent.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/domain/TimeDealEvent.java
@@ -5,12 +5,13 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
-import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Slf4j
 public class TimeDealEvent {
     @Id @GeneratedValue
     @Column(name="time_deal_event_id")
@@ -28,7 +29,12 @@ public class TimeDealEvent {
         this.deliveredCouponNum = 0;
     }
 
-    public void updateDeliveredCouponNum(){
-        this.deliveredCouponNum++;
+    public boolean incrementDeliveredCouponIfPossible(){
+        log.debug("published coupon number is {}, deliveredCoupon number is {}", publishedCouponNum, deliveredCouponNum);
+        if (deliveredCouponNum < publishedCouponNum) {
+            this.deliveredCouponNum++;
+            return true;
+        }
+        return false;
     }
 }

--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/repository/event/RedisTimeDealRepository.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/repository/event/RedisTimeDealRepository.java
@@ -1,0 +1,26 @@
+package com.bjcareer.stockservice.timeDeal.repository.event;
+
+
+import com.bjcareer.stockservice.timeDeal.domain.TimeDealEvent;
+import com.bjcareer.stockservice.timeDeal.repository.InMemoryEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+
+@RequiredArgsConstructor
+public class RedisTimeDealRepository implements InMemoryEventRepository {
+    private final RedissonClient redissonClient;
+
+    @Override
+    public Long save(TimeDealEvent timeDealEvent) {
+        RBucket<TimeDealEvent> bucket = redissonClient.getBucket("timeDeal:" + timeDealEvent.getId());
+        bucket.set(timeDealEvent);
+        return timeDealEvent.getId();
+    }
+
+    @Override
+    public TimeDealEvent findById(Long id) {
+        RBucket<TimeDealEvent> bucket = redissonClient.getBucket("timeDeal:" + id);
+        return bucket.get();
+    }
+}

--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/repository/event/RedisTimeDealRepository.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/repository/event/RedisTimeDealRepository.java
@@ -10,17 +10,20 @@ import org.redisson.api.RedissonClient;
 @RequiredArgsConstructor
 public class RedisTimeDealRepository implements InMemoryEventRepository {
     private final RedissonClient redissonClient;
+    private final String BUCKET = "timeDeal:";
 
     @Override
     public Long save(TimeDealEvent timeDealEvent) {
-        RBucket<TimeDealEvent> bucket = redissonClient.getBucket("timeDeal:" + timeDealEvent.getId());
+        String BUCKET_NAME = BUCKET + timeDealEvent.getId();
+        RBucket<TimeDealEvent> bucket = redissonClient.getBucket(BUCKET_NAME);
         bucket.set(timeDealEvent);
         return timeDealEvent.getId();
     }
 
     @Override
     public TimeDealEvent findById(Long id) {
-        RBucket<TimeDealEvent> bucket = redissonClient.getBucket("timeDeal:" + id);
+        String BUCKET_NAME = BUCKET + id;
+        RBucket<TimeDealEvent> bucket = redissonClient.getBucket(BUCKET_NAME);
         return bucket.get();
     }
 }

--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/service/TimeDealService.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/service/TimeDealService.java
@@ -1,14 +1,17 @@
 package com.bjcareer.stockservice.timeDeal.service;
 
 import com.bjcareer.stockservice.timeDeal.domain.Coupon;
+import com.bjcareer.stockservice.timeDeal.domain.RedisLock;
 import com.bjcareer.stockservice.timeDeal.domain.TimeDealEvent;
 import com.bjcareer.stockservice.timeDeal.repository.CouponRepository;
 import com.bjcareer.stockservice.timeDeal.repository.EventRepository;
+import com.bjcareer.stockservice.timeDeal.repository.InMemoryEventRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.concurrent.CompletableFuture;
+
 
 @Service
 @RequiredArgsConstructor
@@ -16,52 +19,72 @@ import org.springframework.transaction.annotation.Transactional;
 public class TimeDealService {
     private final CouponRepository couponRepository;
     private final EventRepository timeDealEventRepository;
+    private final InMemoryEventRepository inMemoryEventRepository;
+    private final RedisLock redisLock;
 
     @Transactional
-    public TimeDealEvent createTimeDealEvent(int publishedCouponNum){
+    public TimeDealEvent createTimeDealEvent(int publishedCouponNum) {
         log.debug("타임딜 서비스 시작");
-
+        String lockName = "timeDealEventLock";
         TimeDealEvent timeDealEvent = new TimeDealEvent(publishedCouponNum);
-        Long saveId = timeDealEventRepository.save(timeDealEvent);
-        log.debug("저장된 ID는 {}", saveId);
+        boolean isLocked = redisLock.tryLock(lockName);
+
+        if (isLocked){
+            Long saveId = timeDealEventRepository.save(timeDealEvent);
+            inMemoryEventRepository.save(timeDealEvent);
+            redisLock.releaselock(lockName);
+            log.debug("저장된 ID는 {}", saveId);
+        }else {
+            throw new IllegalStateException("레디스 락 획득 실패");
+        }
 
         return timeDealEvent;
     }
 
-    @Transactional(isolation = Isolation.READ_COMMITTED)
-    public Coupon generateCouponToUser(Long eventId, Double discountRate){
-        log.debug("요청된 이벤트 ID {}", eventId);
-        TimeDealEvent timeDealEvent = vaildateEventId(eventId);
+    public Coupon generateCouponToUser(Long eventId, Double discountRate) {
+        log.info("요청된 이벤트 ID {}", eventId);
+        vaildateEventId(eventId);
 
-        log.debug("사용자에게 전달된 쿠폰의 개수는 = {} ", timeDealEvent.getDeliveredCouponNum());
+        String lockName = "generateCouponToUserLock";
+        boolean is_locked = redisLock.tryLock(lockName);
+
+        if (!is_locked) {
+            throw new IllegalStateException("사용자 time-out");
+        }
+
+        log.info("lock 획득 {}", Thread.currentThread().getName());
+
+        TimeDealEvent timeDealEvent = inMemoryEventRepository.findById(eventId);
         vaildateRemainCoupon(timeDealEvent);
-
         timeDealEvent.updateDeliveredCouponNum();
 
+        log.info("사용자에게 전달된 쿠폰의 개수는 = {} ", timeDealEvent.getDeliveredCouponNum());
+
+        inMemoryEventRepository.save(timeDealEvent);
         Coupon result = generateCoupon(discountRate, timeDealEvent);
-        log.debug("발급된 쿠폰 ID는 {}", result.getCouponNumber());
+        log.info("발급된 쿠폰 ID는 {}", result.getCouponNumber());
+        redisLock.releaselock(lockName);
 
         return result;
     }
 
-    private Coupon generateCoupon(Double discountRate, TimeDealEvent timeDealEvent) {
+    protected Coupon generateCoupon(Double discountRate, TimeDealEvent timeDealEvent) {
         Coupon coupon = new Coupon(discountRate, timeDealEvent);
-        couponRepository.save(coupon);
+        couponRepository.saveAsync(coupon);
         return coupon;
     }
 
     private void vaildateRemainCoupon(TimeDealEvent timeDealEvent) {
         if(timeDealEvent.getPublishedCouponNum() <= timeDealEvent.getDeliveredCouponNum()){
-            log.debug("더 이상 발급 불가");
+            timeDealEventRepository.saveAsync(timeDealEvent);
             throw new IllegalStateException("더 이상 발급하지 못함");
         }
     }
 
-    private TimeDealEvent vaildateEventId(Long eventId) {
-        TimeDealEvent timeDealEvent = timeDealEventRepository.findById(eventId);
-        if (timeDealEvent == null){
-            throw  new IllegalStateException("준비된 이벤트가 없음");
+    private void vaildateEventId(Long eventId) {
+        TimeDealEvent byId = inMemoryEventRepository.findById(eventId);
+        if (byId == null) {
+            throw  new IllegalStateException("잘못된 Event를 요청함");
         }
-        return timeDealEvent;
     }
 }

--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/service/TimeDealService.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/service/TimeDealService.java
@@ -27,6 +27,7 @@ public class TimeDealService {
     private final RedisLock redisLock;
     private final String LOCK_KEK = "TIME_DEAL_LOCK";
 
+
     @Transactional
     public Optional<TimeDealEvent> createTimeDealEvent(int publishedCouponNum) {
         log.debug("타임딜 서비스 시작");
@@ -35,12 +36,13 @@ public class TimeDealService {
         boolean isLocked = redisLock.tryLock(LOCK_KEK);
 
         if (!isLocked){
+            log.error("Can't get redis lock'");
             return Optional.empty();
         }
 
         Long saveId = timeDealEventRepository.save(timeDealEvent);
         inMemoryEventRepository.save(timeDealEvent);
-
+        
         redisLock.releaselock(LOCK_KEK);
         log.debug("저장된 ID는 {}", saveId);
 

--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/service/exception/RedisLockAcquisitionException.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/service/exception/RedisLockAcquisitionException.java
@@ -1,0 +1,7 @@
+package com.bjcareer.stockservice.timeDeal.service.exception;
+
+public class RedisLockAcquisitionException extends RuntimeException{
+    public RedisLockAcquisitionException(String message) {
+        super(message);
+    }
+}

--- a/timeDeal/src/test/java/com/bjcareer/stockservice/timeDeal/service/TimeDealServiceTest.java
+++ b/timeDeal/src/test/java/com/bjcareer/stockservice/timeDeal/service/TimeDealServiceTest.java
@@ -1,111 +1,130 @@
 package com.bjcareer.stockservice.timeDeal.service;
 
 import com.bjcareer.stockservice.timeDeal.domain.Coupon;
+import com.bjcareer.stockservice.timeDeal.domain.RedisLock;
 import com.bjcareer.stockservice.timeDeal.domain.TimeDealEvent;
 import com.bjcareer.stockservice.timeDeal.repository.CouponRepository;
 import com.bjcareer.stockservice.timeDeal.repository.EventRepository;
 import com.bjcareer.stockservice.timeDeal.repository.InMemoryEventRepository;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.EntityTransaction;
-import jakarta.transaction.Transactional;
+
+import com.bjcareer.stockservice.timeDeal.service.exception.RedisLockAcquisitionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.test.annotation.Commit;
+import org.mockito.Mock;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
 
-@SpringBootTest
-@EnableAsync
 class TimeDealServiceTest {
-    @Autowired private TimeDealService timeDealService;
-    @Autowired private EventRepository timeDealEventRepository;
-    @Autowired private InMemoryEventRepository inMemoryEventRepository;
-    @Autowired EntityManagerFactory entityManagerFactory;
-    @Autowired EntityManager em;
+    private TimeDealService timeDealService;
+    @Mock private CouponRepository couponRepository;
+    @Mock private RedisLock redisLock;
+    @Mock private EventRepository eventRepository;
+    @Mock private InMemoryEventRepository inMemoryEventRepository;
 
-    TimeDealEvent timeDealEvent;
+    private String LOCK_KEY = "TIME_DEAL_LOCK";
 
     @BeforeEach
-    @Commit
-    @Transactional
     void setUp() {
-        EntityManager entityManager = entityManagerFactory.createEntityManager();
-        EntityTransaction transaction = entityManager.getTransaction();
-        transaction.begin();
-        timeDealEvent = new TimeDealEvent(1);
-        entityManager.persist(timeDealEvent);
-        transaction.commit();
+        redisLock = mock(RedisLock.class);
+        eventRepository = mock(EventRepository.class);
+        inMemoryEventRepository = mock(InMemoryEventRepository.class);
+        couponRepository = mock(CouponRepository.class);
+
+        timeDealService = new TimeDealService(couponRepository, eventRepository, inMemoryEventRepository, redisLock);
     }
 
     @Test
-    void 이벤트_생성_요청(){
-        TimeDealEvent timeDealEvent1 = timeDealService.createTimeDealEvent(100);
-        assertEquals(timeDealEvent1.getPublishedCouponNum(), 100);
-        assertEquals(timeDealEvent1.getDeliveredCouponNum(), 0);
+    void testCreateTimeDealEvent_lockAcquired() {
+        int publishedCouponNum = 100;
+
+        given(redisLock.tryLock(LOCK_KEY)).willReturn(true);
+        given(eventRepository.save(any(TimeDealEvent.class))).willReturn(1L);
+        given(inMemoryEventRepository.save(any(TimeDealEvent.class))).willReturn(1L);
+
+        // when
+        Optional<TimeDealEvent> result = timeDealService.createTimeDealEvent(publishedCouponNum);
+
+        // then
+        assertTrue(result.isPresent(), "The event should be created successfully.");
+        assertEquals(publishedCouponNum, result.get().getPublishedCouponNum(), "Published coupon number should match.");
     }
 
     @Test
-    void 잘못된_이벤트Id로_쿠폰_발급을_요청하는_경우(){
+    void testCreateTimeDealEvent_lockNotAcquired() {
+        int publishedCouponNum = 100;
+
+        given(redisLock.tryLock(LOCK_KEY)).willReturn(false);
+
+        // when
+        Optional<TimeDealEvent> result = timeDealService.createTimeDealEvent(publishedCouponNum);
+
+        // then
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void testGenerateCouponToUser_withInvalidEventId() {
+        // given
+        Long EVENT_ID = 99L;
+
+        given(inMemoryEventRepository.findById(99L)).willReturn(null);
+
+        // then
         assertThrows(IllegalStateException.class , () -> timeDealService.generateCouponToUser(-99L, 20.0));
     }
 
     @Test
-    void 티켓을_더이상_발급할_수_없는_상황일(){
-        TimeDealEvent localTimeDealEvent = new TimeDealEvent(0);
-        timeDealEventRepository.save(localTimeDealEvent);
+    void testGenerateCouponToUser_whenNoMoreTicketsAvailable() {
+        // given
+        Long EVENT_ID = 1L;
 
-        assertThrows(IllegalStateException.class , () -> timeDealService.generateCouponToUser(localTimeDealEvent.getId(), 20.0));
+        given(inMemoryEventRepository.findById(EVENT_ID)).willReturn(new TimeDealEvent(0));
+        given(redisLock.tryLock(LOCK_KEY)).willReturn(true);
+
+        // then
+        assertFalse(timeDealService.generateCouponToUser(EVENT_ID, 20.0).isPresent());
+        verify(eventRepository, times(1)).saveAsync(any(TimeDealEvent.class));
     }
 
     @Test
-    void 사람들이_쿠폰보다_더_많은_수를_요청하는_경우() throws InterruptedException {
-        Long saveId = inMemoryEventRepository.save(timeDealEvent);
+    void testGenerateCouponToUser_whenMoreRequestsThanCouponsAvailable() throws InterruptedException {
+        // setup
+        Long EVENT_ID = 1L;
+        TimeDealEvent timeDealEvent = new TimeDealEvent(1);
 
-        Runnable runnable = () -> {
-            timeDealService.generateCouponToUser(saveId, 20.0); //em공유가 안된다는 점
-        };
+        // given
+        given(inMemoryEventRepository.findById(EVENT_ID)).willReturn(timeDealEvent);
+        given(redisLock.tryLock(LOCK_KEY)).willReturn(true);
 
-        Runnable runnable1 = () -> {
-            try {
-                timeDealService.generateCouponToUser(saveId, 20.0); //em공유가 안된다는 점
-            }catch (Exception e){
+        // then
+        Optional<Coupon> publishedCoupon = timeDealService.generateCouponToUser(EVENT_ID, 20.0);
+        Optional<Coupon> cantGetCoupon = timeDealService.generateCouponToUser(EVENT_ID, 20.0);
 
-            }
+        assertTrue(publishedCoupon.isPresent());
+        assertFalse(cantGetCoupon.isPresent());
 
-        };
-
-        Thread thread = new Thread(runnable, "User A");
-        Thread thread1 = new Thread(runnable1, "User B");
-
-        thread.start();
-        thread1.start();
-
-        thread.join();
-        thread1.join();
-
-        Thread.sleep(500);
-
-        TimeDealEvent event = timeDealEventRepository.findById(timeDealEvent.getId());
-        System.out.println("event = " + event.getDeliveredCouponNum());
-
-        assertEquals(event.getDeliveredCouponNum(), 1);
+        verify(eventRepository, times(1)).saveAsync(any(TimeDealEvent.class));
     }
-
 
     @Test
-    @Transactional
-    void 사람들이_쿠폰보다_더_많은_수를_요청하는_경우_no_thread() throws InterruptedException {
-        timeDealService.generateCouponToUser(timeDealEvent.getId(), 20.0); //em공유가 안된다는 점
-        timeDealService.generateCouponToUser(timeDealEvent.getId(), 20.0); //em공유가 안된다는 점
+    void testGenerateCouponToUser_whenAcquireFailOfRedisLock() throws InterruptedException {
+        // setup
+        Long EVENT_ID = 1L;
+        TimeDealEvent timeDealEvent = new TimeDealEvent(1);
 
+        // given
+        given(inMemoryEventRepository.findById(EVENT_ID)).willReturn(timeDealEvent);
+        given(redisLock.tryLock(LOCK_KEY)).willReturn(true).willReturn(false);
 
-        Thread.sleep(500);
+        // then
+        Optional<Coupon> publishedCoupon = timeDealService.generateCouponToUser(EVENT_ID, 20.0);
+        assertTrue(publishedCoupon.isPresent());
+        verify(inMemoryEventRepository, times(1)).save(any(TimeDealEvent.class));
 
-        assertEquals(1, timeDealEvent.getDeliveredCouponNum());
+        assertThrows(RedisLockAcquisitionException.class, () -> timeDealService.generateCouponToUser(EVENT_ID, 20.0));
     }
-
 }


### PR DESCRIPTION
타임딜의 서비스 구조는 아래와 같습니다.

## 순서도 
- 사용자의 발급 요청 수신: 사용자가 쿠폰 발급을 요청합니다.
- 이벤트 확인: DB에 접근하여 사용자가 요청한 이벤트가 실제로 존재하는지 확인합니다.
- 이벤트가 존재하지 않는 경우: 사용자에게 Bad Request 응답을 보냅니다.
- 이벤트가 존재하는 경우: 사용자가 해당 이벤트에서 쿠폰을 발급받은 이력이 있는지 확인합니다.
- 쿠폰 발급 이력 확인: 사용자가 해당 이벤트에서 쿠폰을 발급받은 이력이 있는지 확인합니다.
- 이력이 있는 경우: 사용자에게 이미 쿠폰을 발급받았다는 응답
- 
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/ca294916-137d-46da-b9ab-bcb901ed861d">




## ERD
서비스 ERD (Entity-Relationship Diagram)에 대해 간단히 설명드리겠습니다. 현재 정의된 쿠폰 서비스는 다음과 같은 테이블들로 구성되어 있습니다:

### 테이블: Coupon
- **할인 금액 (discount_amount)**: 쿠폰을 사용하여 적용될 할인 금액을 나타냅니다.
- **발급 일자 (issued_at)**: 쿠폰이 발급된 날짜를 기록합니다.
- **쿠폰 번호 (coupon_code)**: UUID V4 형식으로 생성된 고유한 쿠폰 번호를 저장합니다.
- **사용 유무 (is_used)**: 쿠폰이 사용되었는지 여부를 나타내는 boolean 타입의 값입니다.

### 테이블: Time_Deal_Event
- **발급된 쿠폰의 개수 (total_coupons_issued)**: 이벤트를 통해 발급된 전체 쿠폰의 수를 기록합니다.
- **사용자에게 전달된 쿠폰 개수 (coupons_distributed_to_users)**: 각 사용자에게 몇 개의 쿠폰이 전달되었는지를 기록합니다.

### 관계
- **Time_Deal_Event (1) -> Coupon (N)**: 하나의 Time_Deal_Event가 여러 개의 쿠폰을 발급할 수 있는 일대다 관계입니다.

<img width="666" alt="스크린샷 2024-07-22 오후 5 05 58" src="https://github.com/user-attachments/assets/2b8adc9c-a500-47de-8f10-5f7055946288">
