### PR TITLE
[feat] Create Service & Controller

### DIFF
--- a/userservice/src/main/java/com/bjcareer/userservice/controller/RegisterController.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/controller/RegisterController.java
@@ -1,0 +1,48 @@
+package com.bjcareer.userservice.controller;
+
+import com.bjcareer.userservice.controller.dto.RegisterDto;
+import com.bjcareer.userservice.controller.dto.RegisterDto.*;
+import com.bjcareer.userservice.domain.User;
+import com.bjcareer.userservice.service.RegisterService;
+import com.bjcareer.userservice.domain.Redis;
+import com.bjcareer.userservice.domain.Telegram;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v0/auth")
+public class RegisterController {
+    private static final Logger log = LoggerFactory.getLogger(RegisterController.class);
+    private final RegisterService registerService;
+    private final Redis redisDomain;
+    private final Telegram telegramDomain;
+
+    @PostMapping("/telegram-authentication")
+    public ResponseEntity<?> generateTokenForRegister(@RequestBody RegisterDtoRequest request) {
+        Long token = registerService.generateRandomTokenForAuthentication(request.getTelegramId());
+        return new ResponseEntity<>(new MobileAuthentication(token, request.getTelegramId()), HttpStatus.OK);
+    }
+
+    @PostMapping("/verify-token")
+    public ResponseEntity<?> verifyTelegramAccount(@RequestBody MobileAuthenticationVerifyRequest request) {
+        log.debug("Id를 {} 위해서 셍성된 랜덤 벨류의 값은? {}", request.getTelegramId(), request.getToken());
+        boolean result = registerService.verifyToken(request.getTelegramId(), request.getToken());
+        return new ResponseEntity<>(new MobileAuthenticationVerifyResponse(result), HttpStatus.OK);
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<?> register(@RequestBody RegisterDtoRequest request) {
+        User requestUser = new User(request.getUserId(), request.getPassword(), request.getTelegramId());
+        String id = registerService.registerService(requestUser);
+        return new ResponseEntity<>(new RegisterResponse(id), HttpStatus.OK);
+    }
+}

--- a/userservice/src/main/java/com/bjcareer/userservice/service/RegisterService.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/service/RegisterService.java
@@ -1,0 +1,77 @@
+package com.bjcareer.userservice.service;
+
+import com.bjcareer.userservice.domain.RandomCodeGenerator;
+import com.bjcareer.userservice.domain.Redis;
+import com.bjcareer.userservice.domain.Telegram;
+import com.bjcareer.userservice.domain.User;
+import com.bjcareer.userservice.repository.DatabaseRepository;
+import com.bjcareer.userservice.repository.RedisRepository;
+import com.bjcareer.userservice.service.exceptions.RedisLockAcquisitionException;
+import com.bjcareer.userservice.service.exceptions.TelegramCommunicationException;
+import com.bjcareer.userservice.service.exceptions.UserAlreadyExistException;
+import com.bjcareer.userservice.service.vo.TokenVO;
+import lombok.Data;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Data
+public class RegisterService {
+    private final DatabaseRepository databaseRepository;
+    private final RedisRepository redisRepository;
+    private final Telegram telegramDomain;
+    private final Redis redisDomain;
+
+    public Long generateRandomTokenForAuthentication(String telegramId) {
+        int EXPIRATION_TIME = 60;
+        Long generate = RandomCodeGenerator.generate();
+        boolean isSend = telegramDomain.sendCode(telegramId, generate);
+
+        if (!isSend) {
+            throw new TelegramCommunicationException("통신 에러");
+        }
+
+        redisRepository.saveToken(new TokenVO(telegramId, generate), EXPIRATION_TIME);
+        return generate;
+    }
+
+    public boolean verifyToken(String telegramId, Long token) {
+        Optional<TokenVO> tokebByTelegramId = redisRepository.findTokebByTelegramId(telegramId);
+
+        if (tokebByTelegramId.isEmpty()){
+            return false;
+        }
+
+        TokenVO tokenVO = tokebByTelegramId.get();
+        return token.equals(tokenVO.getToken());
+    }
+
+    @Transactional
+    public String registerService(User user) {
+        String LOCK_KEY = "auth:register:lock";
+        boolean isLock = redisDomain.tryLock(LOCK_KEY);
+
+        if (!isLock){
+            redisDomain.releaselock(LOCK_KEY);
+            throw new RedisLockAcquisitionException("Server is busy");
+        }
+
+        Optional<User> userIdInDatabase = databaseRepository.findByUserId(user.getUserId());
+        userIdInDatabase.ifPresent(u -> {
+            redisDomain.releaselock(LOCK_KEY);
+            throw new UserAlreadyExistException("ID already exists: " + user.getUserId());
+        });
+
+        boolean isSaved = databaseRepository.save(user);
+
+        if (!isSaved){
+            redisDomain.releaselock(LOCK_KEY);
+            throw new UserAlreadyExistException("User already exist: " + user.getUserId());
+        }
+
+        redisDomain.releaselock(LOCK_KEY);
+        return user.getId();
+    }
+}


### PR DESCRIPTION
 - 회원 가입을 위한 서비스 파일과 Controller 파일을 작성했습니다
 - telegram-authentication의 기능은 사용자가 요청한 ID로 서버에서 메세지를 보낼 수 있는지 검증하기 위한 기능입니다
 - verify-token의 기능은 서버에서 전달한 토큰 값과 사용자가 입력한 토큰 값이 일치하는지 확인하는 기능입니다.
 - register의 기능은 사용자의 아이디와 패스워트 텔레그렘 아이디를 입력 받고, 사용자가 요청하는 아이디가 유니크하면 데이터베이스에 저장하고, 아니면 예외를 발생시켜 다시 입력 받도록 유도합니다.

 related to #17