### PR TITLE
[feat] Creat Auth manager for jwt

### DIFF
--- a/userservice/src/main/java/com/bjcareer/userservice/controller/UserController.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/controller/UserController.java
@@ -1,17 +1,74 @@
 package com.bjcareer.userservice.controller;
 
 
-import static com.bjcareer.userservice.controller.dto.RegisterDTO.*;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import com.bjcareer.userservice.controller.dto.UserDto.*;
+import com.bjcareer.userservice.domain.User;
+import com.bjcareer.userservice.service.JwtService;
+import com.bjcareer.userservice.service.UserService;
+import com.bjcareer.userservice.service.vo.JwtTokenVO;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
-@RestController(value = "/api/v0/user")
+import javax.security.sasl.AuthenticationException;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/v0/user")
 public class UserController {
+    private final UserService userService;
+    private final JwtService jwtService;
 
-    @PostMapping
-    public void Register(@RequestBody RegisterDtoRequest request) {
+    @PostMapping("/login")
+    public ResponseEntity<?> Login(@RequestBody LoginRequest request, HttpServletResponse response) throws AuthenticationException {
+        User user = new User(request.getId(), request.getPassword(), null);
 
+        userService.login(user);
+        JwtTokenVO jwtTokenVO = jwtService.generateToken();
+
+        setCookieForRefreshToken(response, jwtTokenVO);
+        setCookieForSessionId(response, jwtTokenVO);
+
+        LoginResponse res = new LoginResponse(jwtTokenVO.getAccessToken());
+
+        return ResponseEntity.ok(res);
     }
 
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshLogin(@CookieValue("sessionId") String sessionId, @CookieValue("refreshToken") String refreshToken) throws AuthenticationException {
+        JwtTokenVO jwtTokenVO = jwtService.generateAccessTokenViaRefresh(sessionId, refreshToken);
+        LoginResponse res = new LoginResponse(jwtTokenVO.getAccessToken());
+        return ResponseEntity.ok(res);
+    }
+
+    @PostMapping("/test")
+    public ResponseEntity<?> Login()  {
+        return ResponseEntity.ok(null);
+    }
+
+    private void setCookieForRefreshToken(HttpServletResponse response, JwtTokenVO jwtTokenVO) {
+        Cookie cookie = new Cookie("refreshToken", jwtTokenVO.getRefreshToken());
+
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+
+        response.addCookie(cookie);
+    }
+
+
+    private void setCookieForSessionId(HttpServletResponse response, JwtTokenVO jwtTokenVO) {
+        Cookie cookie = new Cookie("sessionId", jwtTokenVO.getSessionId());
+
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+
+        response.addCookie(cookie);
+    }
 }

--- a/userservice/src/main/java/com/bjcareer/userservice/controller/exHandler/UserExceptionHandler.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/controller/exHandler/UserExceptionHandler.java
@@ -1,8 +1,8 @@
 package com.bjcareer.userservice.controller.exHandler;
 
 import com.bjcareer.userservice.controller.UserController;
-import com.bjcareer.userservice.exceptions.UnauthorizedAccessAttemptException;
 import com.bjcareer.userservice.interceptor.LoginInterceptor;
+import com.bjcareer.userservice.service.exceptions.UnauthorizedAccessAttemptException;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import lombok.extern.slf4j.Slf4j;

--- a/userservice/src/main/java/com/bjcareer/userservice/domain/AuthTokenManager.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/domain/AuthTokenManager.java
@@ -1,0 +1,68 @@
+package com.bjcareer.userservice.domain;
+
+import com.bjcareer.userservice.service.vo.JwtTokenVO;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class AuthTokenManager {
+    private final SecretKey signingKey;
+    public static final Long ACCESS_TOKEN_EXPIRE_DURATION_SEC = 30 * 60L; //30분
+    public static final Long REFRESH_TOKEN_EXPIRE_DURATION_SEC = 15 * 24 * 3500L; //15일
+
+    public AuthTokenManager(@Value("${secret.key}") String secretKey) {
+        signingKey = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secretKey));
+    }
+
+    public JwtTokenVO generateToken(String sessionId) {
+        long currentTimeMillis = System.currentTimeMillis();
+
+        String accessToken = generateToken(currentTimeMillis + ACCESS_TOKEN_EXPIRE_DURATION_SEC * 1000L);
+        String refreshToken = generateToken(currentTimeMillis + REFRESH_TOKEN_EXPIRE_DURATION_SEC * 1000L);
+
+        return new JwtTokenVO(accessToken, refreshToken, sessionId, currentTimeMillis + REFRESH_TOKEN_EXPIRE_DURATION_SEC * 1000L);
+    }
+
+    public Claims verifyToken(String token) throws SignatureException, ExpiredJwtException {
+        return Jwts.parser().verifyWith(signingKey).build().parseSignedClaims(token).getPayload();
+    }
+
+    public boolean validateRefreshTokenExpiration(String refreshToken) throws SignatureException, ExpiredJwtException{
+        Claims claims = validateRefreshToken(refreshToken);
+        boolean result = validatAccessTokenExpiration(claims.getExpiration());
+        return result;
+    }
+
+    private Claims validateRefreshToken(String refreshToken) throws SignatureException, ExpiredJwtException {
+        Claims payload = Jwts.parser().verifyWith(signingKey).build().parseSignedClaims(refreshToken).getPayload();
+        return payload;
+    }
+
+    private boolean validatAccessTokenExpiration(Date expiration) throws SignatureException, ExpiredJwtException {
+        if (expiration.after(new Date())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private String generateToken(long expiration) {
+        Date expirationDate = new Date(expiration);
+        return Jwts.builder()
+                .subject(UUID.randomUUID().toString())
+                .issuedAt(new Date())
+                .expiration(expirationDate)
+                .signWith(signingKey)
+                .compact();
+    }
+}

--- a/userservice/src/main/java/com/bjcareer/userservice/domain/User.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/domain/User.java
@@ -1,6 +1,11 @@
 package com.bjcareer.userservice.domain;
 
+import java.nio.charset.Charset;
+
 import com.github.ksuid.KsuidGenerator;
+import com.google.common.base.Charsets;
+import com.google.common.hash.Hashing;
+
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -27,7 +32,7 @@ public class User {
 
     public User(String userId, String password, String telegramId) {
         this.userId = userId;
-        this.password = password;
+        this.password = Hashing.sha256().hashString(password, Charsets.UTF_8).toString();
         this.telegramId = telegramId;
     }
 

--- a/userservice/src/main/java/com/bjcareer/userservice/service/JwtService.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/service/JwtService.java
@@ -1,9 +1,10 @@
 package com.bjcareer.userservice.service;
 
 import com.bjcareer.userservice.domain.AuthTokenManager;
-import com.bjcareer.userservice.exceptions.UnauthorizedAccessAttemptException;
 import com.bjcareer.userservice.repository.RedisRepository;
+import com.bjcareer.userservice.service.exceptions.UnauthorizedAccessAttemptException;
 import com.bjcareer.userservice.service.vo.JwtTokenVO;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/userservice/src/main/java/com/bjcareer/userservice/service/UserService.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/service/UserService.java
@@ -1,0 +1,32 @@
+package com.bjcareer.userservice.service;
+
+import com.bjcareer.userservice.domain.User;
+import com.bjcareer.userservice.repository.DatabaseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.security.sasl.AuthenticationException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final DatabaseRepository databaseRepository;
+
+    @Transactional(readOnly = true)
+    public void login(User inputUser) throws AuthenticationException {
+        Optional<User> userFromDatabase = databaseRepository.findByUserId(inputUser.getUserId());
+
+        if(userFromDatabase.isEmpty()){
+            throw new AuthenticationException("잘못된 ID나 PASSWORD를 입력했습니다.");
+        }
+
+        User storedUser = userFromDatabase.get();
+        boolean isVerify = storedUser.verifyPassword(inputUser.getPassword());
+
+        if(!isVerify){
+            throw new AuthenticationException("잘못된 ID나 PASSWORD를 입력했습니다2.");
+        }
+    }
+}


### PR DESCRIPTION
- error handler를 통해서 사용자에게 전달 할 에러를 작성했습니다.
- AuthManager를 통해서 토큰 검증을 수행합니다
- 사용자가 전달한 ID, PASSWORD를 비교하는 형식으로 로그인 기능을 수행합니다.

related to #21 