### PR TITLE
Feat/error hadling with toss

### DIFF
--- a/payment/src/main/java/com/bjcareer/payment/adapter/out/web/toss/exception/PspConfirmationException.java
+++ b/payment/src/main/java/com/bjcareer/payment/adapter/out/web/toss/exception/PspConfirmationException.java
@@ -1,11 +1,25 @@
 package com.bjcareer.payment.adapter.out.web.toss.exception;
 
-public class PspConfirmationException {
-	String errorCode;
-	String errorMsg;
-	boolean isSuccess = false;
-	boolean isFailure = false;
-	boolean isUnknown = false;
+import lombok.Data;
 
-	boolean isRetryAbleError = false;
+@Data
+public class PspConfirmationException extends RuntimeException{
+	private String errorCode;
+	private String errrMsg;
+
+	private boolean isSuccess = false;
+	private boolean isFailure = false;
+	private boolean isUnknown = false;
+	private boolean isRetryAbleError = false;
+
+	public PspConfirmationException(String errorCode, String errrMsg, TossErrorCode tossErrorCode) {
+		super(errrMsg);
+		this.errorCode = errorCode;
+		this.errrMsg = errrMsg;
+		this.isSuccess = tossErrorCode.isSuccess();
+		this.isFailure = tossErrorCode.isSFailure();
+		this.isUnknown = tossErrorCode.isUnknown();
+
+		this.isRetryAbleError = isUnknown;
+	}
 }

--- a/payment/src/main/java/com/bjcareer/payment/adapter/out/web/toss/exception/TossErrorCode.java
+++ b/payment/src/main/java/com/bjcareer/payment/adapter/out/web/toss/exception/TossErrorCode.java
@@ -2,7 +2,6 @@ package com.bjcareer.payment.adapter.out.web.toss.exception;
 
 public enum TossErrorCode {
 	ACCOUNT_OWNER_CHECK_FAILED("계좌 소유주를 가져오는데 실패했습니다. 은행코드, 계좌번호를 확인해주세요."),
-	ALREADY_CANCELED_PAYMENT("이미 취소된 결제 입니다."),
 	ALREADY_COMPLETED_PAYMENT("이미 완료된 결제 입니다."),
 	ALREADY_EXIST_SUBMALL("이미 존재하는 서브몰입니다."),
 	BELOW_MINIMUM_AMOUNT("신용카드는 결제금액이 100원 이상, 계좌는 200원이상부터 결제가 가능합니다."),
@@ -28,7 +27,31 @@ public enum TossErrorCode {
 		this.koreanMessage = koreanMessage;
 	}
 
-	public String getKoreanMessage() {
-		return koreanMessage;
+
+	public TossErrorCode getErrorCode(String msg) {
+		return TossErrorCode.valueOf(msg);
+	}
+
+	public Boolean isSuccess(){
+		return this == TossErrorCode.ALREADY_COMPLETED_PAYMENT;
+	}
+
+	public Boolean isSFailure(){
+		switch (this){
+			case BELOW_MINIMUM_AMOUNT:
+			case BELOW_ZERO_AMOUNT:
+			case EXCEED_MAX_AMOUNT:
+			case INVALID_CARD:
+			case INVALID_ACCOUNT_NUMBER:
+			case INVALID_PASSWORD:
+			case NOT_FOUND:
+				return true;
+		}
+
+		return false;
+	}
+
+	public Boolean isUnknown(){
+		return !isSuccess() && !isSFailure();
 	}
 }

--- a/payment/src/main/java/com/bjcareer/payment/adapter/out/web/toss/executor/TossPaymentExecutor.java
+++ b/payment/src/main/java/com/bjcareer/payment/adapter/out/web/toss/executor/TossPaymentExecutor.java
@@ -1,8 +1,15 @@
 package com.bjcareer.payment.adapter.out.web.toss.executor;
 
+import java.time.Duration;
+import java.time.temporal.TemporalUnit;
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import com.bjcareer.payment.adapter.out.web.toss.exception.PspConfirmationException;
+import com.bjcareer.payment.adapter.out.web.toss.exception.TossErrorCode;
+import com.bjcareer.payment.adapter.out.web.toss.response.TossFailureResponse;
 import com.bjcareer.payment.adapter.out.web.toss.response.TossPaymentExecutionResponse;
 import com.bjcareer.payment.application.domain.PaymentConfirmResult;
 import com.bjcareer.payment.application.domain.PaymentExecutionResult;
@@ -10,6 +17,7 @@ import com.bjcareer.payment.application.domain.PaymentExecutionResult;
 
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
 @Component
 @RequiredArgsConstructor
@@ -27,10 +35,18 @@ public class TossPaymentExecutor implements PaymentExecutor {
 			.retrieve()
 			.onStatus(
 				httpStatusCode -> httpStatusCode.is4xxClientError() || httpStatusCode.is5xxServerError(),
-				clientResponse -> Mono.error(new RuntimeException("Failed to communicate with Toss: " + clientResponse.statusCode()))
+				clientResponse -> clientResponse.bodyToMono(TossFailureResponse.class)
+					.flatMap(it -> {
+						TossErrorCode tossErrorCode = TossErrorCode.valueOf(it.getCode());
+						PspConfirmationException pspConfirmationException = new PspConfirmationException(
+							it.getCode(), it.getMessage(), tossErrorCode);
+						return Mono.error(pspConfirmationException);
+					})
 			)
-			.bodyToMono(TossPaymentExecutionResponse.class);
+			.bodyToMono(TossPaymentExecutionResponse.class)
+			.retryWhen(Retry.backoff(3, Duration.ofSeconds(2)).jitter(2.0));
 
 		return tossPaymentExecutionResponseMono.flatMap(it -> Mono.just(new PaymentExecutionResult(it.getPaymentKey(), it.getOrderId(), it.getOrderName(), it.getTotalAmount(), it.getStatus(), it.getRequestedAt(), it.getApprovedAt(), true, false, false)));
 	}
+
 }

--- a/payment/src/main/java/com/bjcareer/payment/adapter/out/web/toss/executor/TossPaymentExecutor.java
+++ b/payment/src/main/java/com/bjcareer/payment/adapter/out/web/toss/executor/TossPaymentExecutor.java
@@ -1,8 +1,7 @@
 package com.bjcareer.payment.adapter.out.web.toss.executor;
 
 import java.time.Duration;
-import java.time.temporal.TemporalUnit;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -14,20 +13,31 @@ import com.bjcareer.payment.adapter.out.web.toss.response.TossPaymentExecutionRe
 import com.bjcareer.payment.application.domain.PaymentConfirmResult;
 import com.bjcareer.payment.application.domain.PaymentExecutionResult;
 
-
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
+import reactor.util.retry.RetryBackoffSpec;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Component
 @RequiredArgsConstructor
 public class TossPaymentExecutor implements PaymentExecutor {
-	private final WebClient webClient;
 
+	private static final Logger logger = LoggerFactory.getLogger(TossPaymentExecutor.class);
+
+	public static final int MAX_ATTEMPTS = 3;
+	public static final int WAIT_TIME = 2;
+	public static final double JITTER_FACTOR = 0.1;
+	private final WebClient webClient;
 
 	@Override
 	public Mono<PaymentExecutionResult> execute(PaymentConfirmResult paymentConfirmResult) {
 		String uri = "/v1/payments/confirm";
+
+		logger.info("Executing payment confirmation for Order ID: {}", paymentConfirmResult.getOrderId());
+
 		Mono<TossPaymentExecutionResponse> tossPaymentExecutionResponseMono = webClient.post()
 			.uri(uri)
 			.header("Idempotent-Key", paymentConfirmResult.getOrderId())
@@ -36,17 +46,45 @@ public class TossPaymentExecutor implements PaymentExecutor {
 			.onStatus(
 				httpStatusCode -> httpStatusCode.is4xxClientError() || httpStatusCode.is5xxServerError(),
 				clientResponse -> clientResponse.bodyToMono(TossFailureResponse.class)
-					.flatMap(it -> {
-						TossErrorCode tossErrorCode = TossErrorCode.valueOf(it.getCode());
-						PspConfirmationException pspConfirmationException = new PspConfirmationException(
-							it.getCode(), it.getMessage(), tossErrorCode);
-						return Mono.error(pspConfirmationException);
-					})
+					.flatMap(TossPaymentExecutor::getPspConfirmException)
 			)
 			.bodyToMono(TossPaymentExecutionResponse.class)
-			.retryWhen(Retry.backoff(3, Duration.ofSeconds(2)).jitter(2.0));
+			.doOnNext(response -> logger.info("Received response from Toss API for Order ID: {}", response.getOrderId()))
+			.retryWhen(getRetrySpec(paymentConfirmResult));
 
-		return tossPaymentExecutionResponseMono.flatMap(it -> Mono.just(new PaymentExecutionResult(it.getPaymentKey(), it.getOrderId(), it.getOrderName(), it.getTotalAmount(), it.getStatus(), it.getRequestedAt(), it.getApprovedAt(), true, false, false)));
+		return tossPaymentExecutionResponseMono
+			.flatMap(it -> {
+				logger.info("Payment confirmation successful for Order ID: {}", it.getOrderId());
+				return Mono.just(new PaymentExecutionResult(it.getPaymentKey(), it.getOrderId(), it.getOrderName(),
+					it.getTotalAmount(), it.getStatus(), it.getRequestedAt(), it.getApprovedAt(), true, false, false));
+			});
 	}
 
+	private static Mono<Throwable> getPspConfirmException(TossFailureResponse response) {
+		TossErrorCode tossErrorCode = TossErrorCode.valueOf(response.getCode());
+		PspConfirmationException pspConfirmationException = new PspConfirmationException(
+			response.getCode(), response.getMessage(), tossErrorCode);
+		logger.error("Payment confirmation failed with error code: {}, message: {}", response.getCode(), response.getMessage());
+		return Mono.error(pspConfirmationException);
+	}
+
+	private RetryBackoffSpec getRetrySpec(PaymentConfirmResult paymentConfirmResult) {
+		return Retry.backoff(MAX_ATTEMPTS, Duration.ofSeconds(WAIT_TIME)).jitter(JITTER_FACTOR)
+			.filter(this::shouldRetry) // 특정 조건에 따라 재시도
+			.doBeforeRetry(retrySignal -> logger.warn("Retrying payment confirmation for Order ID: {}. Attempt: {}",
+				paymentConfirmResult.getOrderId(), retrySignal.totalRetries() + 1));
+	}
+
+	private boolean shouldRetry(Throwable throwable) {
+		if (throwable instanceof PspConfirmationException) {
+			PspConfirmationException ex = (PspConfirmationException) throwable;
+			return ex.isRetryAbleError();
+		}
+
+		if (throwable instanceof TimeoutException) {
+			return true;
+		}
+
+		return false;
+	}
 }

--- a/payment/src/main/java/com/bjcareer/payment/adapter/out/web/toss/response/TossFailureResponse.java
+++ b/payment/src/main/java/com/bjcareer/payment/adapter/out/web/toss/response/TossFailureResponse.java
@@ -1,0 +1,9 @@
+package com.bjcareer.payment.adapter.out.web.toss.response;
+
+import lombok.Data;
+
+@Data
+public class TossFailureResponse {
+	private String code;
+	private String message;
+}

--- a/payment/src/main/java/com/bjcareer/payment/application/service/PaymentConfirmService.java
+++ b/payment/src/main/java/com/bjcareer/payment/application/service/PaymentConfirmService.java
@@ -1,10 +1,17 @@
 package com.bjcareer.payment.application.service;
 
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeoutException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.bjcareer.payment.adapter.out.web.toss.exception.PspConfirmationException;
 import com.bjcareer.payment.application.domain.PaymentConfirmResult;
 import com.bjcareer.payment.application.domain.PaymentExecutionResult;
 import com.bjcareer.payment.application.domain.PaymentStatusUpdateCommand;
+import com.bjcareer.payment.application.domain.entity.order.PaymentStatus;
 import com.bjcareer.payment.application.port.in.PaymentConfirmCommand;
 import com.bjcareer.payment.application.port.in.PaymentConfirmUsecase;
 import com.bjcareer.payment.application.port.out.PaymentExecutionPort;
@@ -19,6 +26,7 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class PaymentConfirmService implements PaymentConfirmUsecase {
 
+	private static final Logger log = LoggerFactory.getLogger(PaymentConfirmService.class);
 	private final PaymentStatusUpdatePort paymentStatusUpdatePort;
 	private final PaymentValidationPort paymentValidationPort;
 	private final PaymentExecutionPort paymentExecutionPort;
@@ -26,17 +34,34 @@ public class PaymentConfirmService implements PaymentConfirmUsecase {
 	@Override
 	public Mono<PaymentExecutionResult> confirm(PaymentConfirmCommand command) {
 		return validatePayment(command)
-			.flatMap(valid -> {
-				if (valid) {
-					return processPayment(command);
+			.filter(isValid -> isValid)
+			.flatMap(isValid -> processPayment(command))
+			.onErrorResume(throwable -> {
+				PaymentStatusUpdateCommand updateCmd;
+				if (throwable instanceof PaymentValidationException) {
+					updateCmd = createUpdateStatusCommandWhenErrorRaise(command.getCheckoutId(), PaymentStatus.FAILURE, throwable.getMessage());
+				} else if (throwable instanceof PspConfirmationException pspException) {
+					updateCmd = createUpdateStatusCommandWhenErrorRaise(command.getCheckoutId(), pspException.getPaymentStatus(),
+						pspException.getErrrMsg());
+				} else if (throwable instanceof TimeoutException) {
+					updateCmd = createUpdateStatusCommandWhenErrorRaise(command.getCheckoutId(), PaymentStatus.EXECUTING,
+						"TimeoutException");
+				}else{
+					updateCmd = createUpdateStatusCommandWhenErrorRaise(command.getCheckoutId(), PaymentStatus.UNKNOWN, throwable.getMessage());
 				}
-				return Mono.error(new PaymentValidationException("요청한 결제 정보가 잘못됐습니다"));
+				return paymentStatusUpdatePort.updatePaymentStatus(updateCmd)
+					.then(Mono.error(throwable));
 			});
 	}
 
 	private Mono<Boolean> validatePayment(PaymentConfirmCommand command) {
-		return paymentValidationPort.isVaild(command.getCheckoutId(), command.getAmount())
-			.doOnNext(valid -> System.out.println("valid = " + valid));
+		return paymentValidationPort.isValid(command.getCheckoutId(), command.getAmount())
+			.filterWhen(valid -> {
+				if (!valid) {
+					return Mono.error(new PaymentValidationException("요청한 결제 정보가 잘못됐습니다"));
+				}
+				return Mono.just(true);
+			});
 	}
 
 	private Mono<PaymentExecutionResult> processPayment(PaymentConfirmCommand command) {
@@ -46,7 +71,8 @@ public class PaymentConfirmService implements PaymentConfirmUsecase {
 	}
 
 	private Mono<PaymentConfirmResult> updatePaymentStatusToExecuting(PaymentConfirmCommand command) {
-		return paymentStatusUpdatePort.updatePaymentStatusToExecuting(command.getCheckoutId(), command.getPaymentKey())
+		PaymentStatusUpdateCommand updateCommand = new PaymentStatusUpdateCommand(command.getCheckoutId(), PaymentStatus.EXECUTING, LocalDateTime.now(), "Confirm 요청");
+		return paymentStatusUpdatePort.updatePaymentStatusToExecuting(updateCommand, command.getPaymentKey())
 			.thenReturn(new PaymentConfirmResult(command.getPaymentKey(), command.getCheckoutId(), command.getAmount()));
 	}
 
@@ -55,8 +81,12 @@ public class PaymentConfirmService implements PaymentConfirmUsecase {
 	}
 
 	private Mono<PaymentExecutionResult> finalizePaymentStatus(PaymentExecutionResult executionResult) {
-		return paymentStatusUpdatePort.updatePaymentStatus(
-				new PaymentStatusUpdateCommand(executionResult.getCheckoutId(), executionResult.getStatus(), executionResult.getApprovedAt()))
+		PaymentStatusUpdateCommand updateCommand = new PaymentStatusUpdateCommand(executionResult.getCheckoutId(), executionResult.getStatus(), executionResult.getApprovedAt(), "Confirm 응답 기록");
+		return paymentStatusUpdatePort.updatePaymentStatus(updateCommand)
 			.thenReturn(executionResult);
+	}
+
+	public PaymentStatusUpdateCommand createUpdateStatusCommandWhenErrorRaise(String checkoutId, PaymentStatus status, String reason) {
+		return new PaymentStatusUpdateCommand(checkoutId, status, LocalDateTime.now(), reason);
 	}
 }

--- a/payment/src/test/java/com/bjcareer/payment/adapter/out/web/toss/executor/TossPaymentExecutorTest.java
+++ b/payment/src/test/java/com/bjcareer/payment/adapter/out/web/toss/executor/TossPaymentExecutorTest.java
@@ -1,6 +1,8 @@
 package com.bjcareer.payment.adapter.out.web.toss.executor;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -14,6 +16,7 @@ import reactor.test.StepVerifier;
 @SpringBootTest
 class TossPaymentExecutorTest {
 	@Autowired PaymentExecutor paymentExecutor;
+
 
 	@Test
 	void 토스_요청가는지_테스트(){

--- a/payment/src/test/java/com/bjcareer/payment/helper/PSPWebClientConfiguration.java
+++ b/payment/src/test/java/com/bjcareer/payment/helper/PSPWebClientConfiguration.java
@@ -1,0 +1,33 @@
+package com.bjcareer.payment.helper;
+
+import java.util.Base64;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.bjcareer.payment.TossConfig;
+
+import lombok.RequiredArgsConstructor;
+
+@SpringBootConfiguration
+@RequiredArgsConstructor
+public class PSPWebClientConfiguration {
+	public final TossConfig tossConfig;
+	@Autowired
+	private WebClient.Builder webClientBuilder;
+
+	public WebClient tossPaymentWebClient(String errorCode){
+		String encodedSecretKey = Base64.getEncoder().encodeToString((tossConfig.getSecretKey() + ":").getBytes());
+		WebClient build = webClientBuilder.baseUrl(tossConfig.getUrl())
+			.defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + encodedSecretKey)
+			.defaultHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+			.defaultHeader("TossPayments-Test-Code", errorCode)
+			.build();
+
+		return build;
+	}
+
+}


### PR DESCRIPTION
# 재시도 전략

재시도 전략으로는 상태 기반과 Jitter 전략을 사용했습니다.

상태 기반 재시도 방식의 예는 다음과 같은 두 가지 상황을 고려해 볼 수 있습니다.

1. **고객 카드 한도 초과**: 이는 고객의 자금 문제로 인한 오류이며, 재시도를 해도 성공할 가능성이 없으므로 즉시 실패 처리해야 합니다.
2. **카드사 네트워크 장애**: 네트워크 문제로 인해 일시적으로 결제가 실패한 경우입니다. 이 경우에는 재시도를 통해 성공 가능성을 높일 수 있습니다.

```java
private RetryBackoffSpec getRetrySpec(PaymentConfirmResult paymentConfirmResult) {
    return Retry.backoff(MAX_ATTEMPTS, Duration.ofSeconds(WAIT_TIME)).jitter(JITTER_FACTOR)
        .filter(this::shouldRetry) // 특정 조건에 따라 재시도
        .doBeforeRetry(retrySignal -> logger.warn("Retrying payment confirmation for Order ID: {}. Attempt: {}",
            paymentConfirmResult.getOrderId(), retrySignal.totalRetries() + 1));
}
```

related to #52 