### PR TITLE
[feat] Add scheduler for crawling

### DIFF
--- a/search/build.gradle
+++ b/search/build.gradle
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
+		languageVersion = JavaLanguageVersion.of(21)
 	}
 }
 
@@ -35,6 +35,11 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.apache.commons:commons-csv:1.8'
 	testImplementation 'org.mockito:mockito-core:5.12.0'
+
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	//parsing html
+	implementation 'org.jsoup:jsoup:1.15.4'
 
 	// https://mvnrepository.com/artifact/org.mongodb/mongodb-driver-sync
 	implementation 'org.mongodb:mongodb-driver-sync:5.1.3'

--- a/search/src/main/java/com/bjcareer/search/RedisConfig.java
+++ b/search/src/main/java/com/bjcareer/search/RedisConfig.java
@@ -12,7 +12,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Configuration
+@Slf4j
 public class RedisConfig {
 
 	@Value("#{'${redis.address}'.split(',')}")
@@ -30,7 +33,6 @@ public class RedisConfig {
 		List<RedissonClient> redissonClients = new ArrayList<>();
 
 		for (String address : adddress) {
-			System.out.println("\"연결되는 중\" + address = " + "연결되는 중" + address);
 			Config config = new Config();
 			SingleServerConfig singleServerConfig = config.useSingleServer();
 			singleServerConfig.setAddress(address);
@@ -40,7 +42,7 @@ public class RedisConfig {
 			redissonClients.add(Redisson.create(config));
 		}
 
-		System.out.println("redissonClients = " + redissonClients);
+		log.debug("redissonClients = {}", redissonClients);
 		return redissonClients;
 	}
 

--- a/search/src/main/java/com/bjcareer/search/SearchApplication.java
+++ b/search/src/main/java/com/bjcareer/search/SearchApplication.java
@@ -3,8 +3,10 @@ package com.bjcareer.search;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 @EnableConfigurationProperties({MongoDBConfig.class})
 public class SearchApplication {
 

--- a/search/src/main/java/com/bjcareer/search/domain/entity/Market.java
+++ b/search/src/main/java/com/bjcareer/search/domain/entity/Market.java
@@ -1,0 +1,5 @@
+package com.bjcareer.search.domain.entity;
+
+public enum Market {
+	KOSPI, KOSDAQ, NASDAQ
+}

--- a/search/src/main/java/com/bjcareer/search/domain/entity/Stock.java
+++ b/search/src/main/java/com/bjcareer/search/domain/entity/Stock.java
@@ -1,0 +1,83 @@
+package com.bjcareer.search.domain.entity;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.BatchSize;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Stock {
+	@Id
+	@GeneratedValue
+	@Column(name="STOCK_ID")
+	private Long id;
+
+	@Column(unique = true)
+	private String code;
+	private String name;
+
+	@Enumerated(EnumType.STRING)
+	private Market market;
+	private String href;
+
+	private Long issuedShares;
+	private Long price;
+	private Long marketCapitalization;
+
+	@OneToMany(mappedBy = "stock", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	@BatchSize(size = 10)
+	List<Thema> themas = new ArrayList<>();
+
+	public Stock(String code, String name, Market market, String href, Long issuedShares, Long price) {
+		this.code = code;
+		this.name = name;
+		this.market = market;
+		this.href = href;
+		this.issuedShares = issuedShares;
+		this.price = price;
+
+		if (issuedShares != null && price != null) {
+			this.marketCapitalization = issuedShares * price;
+		}else {
+			this.marketCapitalization = 0L;
+		}
+	}
+
+	public Stock(String code, String name) {
+		this(code, name, null, null, null, null);
+	}
+
+	@Override
+	public String toString() {
+		return "Stock{" +
+			"id=" + id +
+			", code='" + code + '\'' +
+			", name='" + name + '\'' +
+			", market=" + market +
+			", href='" + href + '\'' +
+			", issuedShares=" + issuedShares +
+			", price=" + price +
+			", marketCapitalization=" + marketCapitalization +
+			'}';
+	}
+
+	public boolean validStock() {
+		return issuedShares != null && price != null;
+	}
+}

--- a/search/src/main/java/com/bjcareer/search/domain/entity/Thema.java
+++ b/search/src/main/java/com/bjcareer/search/domain/entity/Thema.java
@@ -1,0 +1,62 @@
+package com.bjcareer.search.domain.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.hibernate.annotations.BatchSize;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "thema", uniqueConstraints = {
+	@UniqueConstraint(columnNames = {"stock_id", "thema_info_id"})  // 복합 유니크 키 설정
+})
+public class Thema {
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "STOCK_ID")
+	private Stock stock;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "THEMA_INFO_ID")
+	private ThemaInfo themaInfo;
+
+	private LocalDateTime updatedAt;
+
+	public Thema(Stock stock, ThemaInfo themaInfo) {
+		this.stock = stock;
+		this.themaInfo = themaInfo;
+		this.updatedAt = LocalDateTime.now();
+	}
+
+	public String getKey(){
+		return UUID.nameUUIDFromBytes((stock.getCode() + themaInfo.getName()).getBytes()).toString();
+	}
+
+	@Override
+	public String toString() {
+		return "Thema{" +
+			"id=" + id +
+			", stock=" + stock +
+			", themaInfo=" + themaInfo +
+			", updatedAt=" + updatedAt +
+			'}';
+	}
+}

--- a/search/src/main/java/com/bjcareer/search/domain/entity/ThemaInfo.java
+++ b/search/src/main/java/com/bjcareer/search/domain/entity/ThemaInfo.java
@@ -1,0 +1,52 @@
+package com.bjcareer.search.domain.entity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.annotations.BatchSize;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ThemaInfo {
+	@Id
+	@GeneratedValue
+	@Column(name = "THEMA_INFO_ID")
+	private Long id;
+
+	private String name;
+	private String href;
+
+	@OneToMany(mappedBy = "themaInfo", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	@BatchSize(size = 10)
+	private List<Thema> themas = new ArrayList<>();
+
+	public ThemaInfo(String name, String href) {
+		this.name = name;
+		this.href = href;
+	}
+
+	public ThemaInfo(String name) {
+		this(name, null);
+	}
+
+	@Override
+	public String toString() {
+		return "ThemaInfo{" +
+			"id=" + id +
+			", name='" + name + '\'' +
+			", href='" + href + '\'' +
+			'}';
+	}
+}

--- a/search/src/main/java/com/bjcareer/search/out/crawling/naver/CrawlingThema.java
+++ b/search/src/main/java/com/bjcareer/search/out/crawling/naver/CrawlingThema.java
@@ -1,0 +1,155 @@
+package com.bjcareer.search.out.crawling.naver;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+
+import com.bjcareer.search.domain.entity.Market;
+import com.bjcareer.search.domain.entity.Stock;
+import com.bjcareer.search.domain.entity.Thema;
+import com.bjcareer.search.domain.entity.ThemaInfo;
+
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@NoArgsConstructor
+@Component
+public class CrawlingThema {
+	private static final String BASE_URL = "https://finance.naver.com";
+	private static final String THEME_URL = BASE_URL + "/sise/theme.naver?page=";
+	private static final String STOCK_DETAIL_URL = BASE_URL + "/item/main.naver?code=";
+
+	private Map<String, Stock> stocks = new HashMap<>();
+	private Map<String, ThemaInfo> themaInfos = new HashMap<>();
+	private Map<String, Thema> themas = new HashMap<>();
+
+	public CrawlingThema(Map<String, Stock> stocks, Map<String, ThemaInfo> themaInfoMap, Map<String, Thema> themas) {
+		this.stocks = stocks;
+		this.themaInfos = themaInfoMap;
+		this.themas = themas;
+	}
+
+	// 테마 크롤링
+	public void crawlingThema(Integer page)  {
+		log.info("Executing in thread: {}, page: {}" , Thread.currentThread().getName(), page);
+
+		// 테마 목록 크롤링
+		List<ThemaInfo> themaList = getThemaInfoList(page);
+
+		// 각 테마에 속한 종목 정보를 크롤링하고, 결과 목록에 추가
+		for (ThemaInfo themaInfo : themaList) {
+			themaInfos.putIfAbsent(themaInfo.getName(), themaInfo); // 중복 방지
+			List<Stock> stockInfoList = getStockInfoList(themaInfo.getHref());
+
+			for (Stock stock : stockInfoList) {
+				stocks.putIfAbsent(stock.getCode(), stock); // 중복 방지
+				Thema thema = new Thema(stocks.get(stock.getCode()), themaInfos.get(themaInfo.getName()));
+				themas.putIfAbsent(thema.getKey(), thema); // 중복 방지
+			}
+		}
+	}
+
+	// 테마 정보 목록을 가져오는 메서드
+	private List<ThemaInfo> getThemaInfoList(int page)  {
+		List<ThemaInfo> themaList = new ArrayList<>();
+		Elements themaElements = getElements(THEME_URL + page, "table.theme td.col_type1 a");
+
+		for (Element element : themaElements) {
+			String themaName = element.text();
+			String themaLink = BASE_URL + element.attr("href");
+			themaList.add(new ThemaInfo(themaName, themaLink));
+		}
+		return themaList;
+	}
+
+	private List<Stock> getStockInfoList(String themaLink) {
+		List<Stock> stocks = new ArrayList<>();
+		Elements stockElements = getElements(themaLink, "table.type_5 td a");
+
+		for (Element element : stockElements) {
+			String stockLink = BASE_URL + element.attr("href");
+
+			if (stockLink.contains("/item/main.naver")) {
+				String stockName = element.text();
+				String stockCode = extractStockCode(stockLink);
+
+				if (stockCode != null) {
+					Stock stock = getStock(stockCode, stockName);
+
+					if (stock.validStock()){
+						stocks.add(stock);
+					}
+				}
+			}
+		}
+		return stocks;
+	}
+
+	// 종목 코드 추출
+	private String extractStockCode(String stockLink) {
+		String[] stockCodeArray = stockLink.split("code=");
+		return stockCodeArray.length > 1 ? stockCodeArray[1] : null;
+	}
+
+	// 종목 정보 가져오는 메서드
+	public Stock getStock(String stockCode, String stockName) {
+		try {
+			Document stockPage = Jsoup.connect(STOCK_DETAIL_URL + stockCode).get();
+			Market marketType = getMarketType(stockPage);
+			Long issuedShares = getLongValue(stockPage, "th:contains(상장주식수) + td");
+			Long currentPrice = getLongValue(stockPage, "p.no_today span.blind"); //현재가 추출
+			return new Stock(stockCode, stockName, marketType, STOCK_DETAIL_URL + stockCode, issuedShares, currentPrice);
+		} catch (IOException e) {
+			log.error("Json parsing error " + e.getMessage());
+			return new Stock(stockCode, stockName, null, null, null, null);
+		}catch (NumberFormatException e){
+			return new Stock(stockCode, stockName, null, null, null, null);
+		}
+	}
+
+	// 시장 구분(KOSPI, KOSDAQ) 가져오는 메서드
+	private Market getMarketType(Document stockPage) {
+		// 네이버 금융의 새로운 구조에 맞는 선택자 확인
+		Element marketElement = stockPage.selectFirst(".wrap_company img");
+
+		if (marketElement != null) {
+			String marketImgAlt = marketElement.attr("alt");
+			if (marketImgAlt.contains("코스피")) return Market.KOSPI;
+			else if (marketImgAlt.contains("코스닥")) return Market.KOSDAQ;
+		}
+		return null;
+	}
+
+
+	// Long 타입 값을 추출하는 메서드
+	private Long getLongValue(Document document, String cssQuery) {
+		Element element = document.selectFirst(cssQuery);
+
+		try {
+			return Long.parseLong(element.text().replace(",", ""));
+		} catch (NumberFormatException e) {
+			log.error("Error parsing long value for query '{}': {}", cssQuery, e.getMessage());
+			throw e;
+		}
+	}
+
+	// HTML 요소 리스트를 가져오는 공통 메서드
+	private Elements getElements(String url, String cssQuery) {
+		try {
+			Document document = Jsoup.connect(url).get();
+			return document.select(cssQuery);
+		}catch (IOException e) {
+			log.error("Error while connecting to URL: " + url, e);
+			return new Elements();
+		}
+	}
+}

--- a/search/src/main/java/com/bjcareer/search/repository/stock/StockRepository.java
+++ b/search/src/main/java/com/bjcareer/search/repository/stock/StockRepository.java
@@ -1,0 +1,20 @@
+package com.bjcareer.search.repository.stock;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.bjcareer.search.domain.entity.Stock;
+
+@Repository
+public interface StockRepository extends JpaRepository<Stock, Long>{
+	@Query("SELECT s FROM Stock s WHERE s.name LIKE %:name%")
+	List<Stock> findByStockNameContaining(String name);
+
+	Optional<Stock> findByName(String name);
+
+	Optional<Stock> findByCode(String code);
+}

--- a/search/src/main/java/com/bjcareer/search/repository/stock/ThemaInfoRepository.java
+++ b/search/src/main/java/com/bjcareer/search/repository/stock/ThemaInfoRepository.java
@@ -1,0 +1,19 @@
+package com.bjcareer.search.repository.stock;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.bjcareer.search.domain.entity.ThemaInfo;
+
+public interface ThemaInfoRepository extends JpaRepository<ThemaInfo, Long> {
+
+	@Query("SELECT t FROM ThemaInfo t join fetch t.themas s join fetch s.stock  WHERE t.name LIKE %:thema%")
+	List<ThemaInfo> findByNameContains(String thema);
+
+
+	@Query("SELECT t FROM ThemaInfo t WHERE t.name = :thema")
+	Optional<ThemaInfo> findByThemaName(String thema);
+}

--- a/search/src/main/java/com/bjcareer/search/repository/stock/ThemaRepository.java
+++ b/search/src/main/java/com/bjcareer/search/repository/stock/ThemaRepository.java
@@ -1,0 +1,17 @@
+package com.bjcareer.search.repository.stock;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.bjcareer.search.domain.entity.Thema;
+
+public interface ThemaRepository extends JpaRepository<Thema, Long> {
+	@Query("SELECT t FROM Thema t join fetch t.stock s join fetch  t.themaInfo ti WHERE t.stock.name LIKE %:name%")
+	List<Thema> findByStockNameContaining(String name);
+
+	@Query("SELECT t FROM Thema t WHERE t.stock.name = :stockName AND t.themaInfo.name = :themaName")
+	Optional<Thema> findByStockNameAndThemaName(String stockName, String themaName);
+}

--- a/search/src/main/java/com/bjcareer/search/schedule/ScheduleCrawlingService.java
+++ b/search/src/main/java/com/bjcareer/search/schedule/ScheduleCrawlingService.java
@@ -1,0 +1,78 @@
+package com.bjcareer.search.schedule;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bjcareer.search.domain.entity.Stock;
+import com.bjcareer.search.domain.entity.Thema;
+import com.bjcareer.search.domain.entity.ThemaInfo;
+import com.bjcareer.search.out.crawling.naver.CrawlingThema;
+import com.bjcareer.search.repository.stock.StockRepository;
+import com.bjcareer.search.repository.stock.ThemaInfoRepository;
+import com.bjcareer.search.repository.stock.ThemaRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class ScheduleCrawlingService {
+	public final Integer MAX_PAGE = 8;
+
+	private final ThemaInfoRepository themaInfoRepository;
+	private final StockRepository stockRepository;
+	private final ThemaRepository themaRepository;
+
+	@Scheduled(cron = "0 30 4 * * *")
+	@Transactional
+	public void run() {
+		long startTime = System.currentTimeMillis(); // 시작 시간 측정
+		log.info("CrawlingService run");
+
+		Map<String, Stock> stocks = stockRepository.findAll()
+			.stream()
+			.collect(Collectors.toMap(Stock::getCode, stock -> stock));
+
+		Map<String, ThemaInfo> themaInfos = themaInfoRepository.findAll()
+			.stream()
+			.collect(Collectors.toMap(ThemaInfo::getName, themaInfo -> themaInfo));
+
+		Map<String, Thema> themas = themaRepository.findAll()
+			.stream()
+			.collect(Collectors.toMap(Thema::getKey, thema -> thema));
+
+
+		CrawlingThema crawlingThema = new CrawlingThema(stocks, themaInfos, themas);
+
+
+		try (var executor = Executors.newVirtualThreadPerTaskExecutor()) { // 경량 쓰레드 전용 Executor 사용
+			for (int i = 1; i <= MAX_PAGE; i++) {
+				int page = i;
+				executor.submit(() -> {
+					try {
+						crawlingThema.crawlingThema(page); // 크롤링 작업을 경량 쓰레드에서 실행
+					} catch (Exception e) {
+						log.error("Error while crawling page: " + page, e);
+					}
+				});
+			}
+		}
+
+		long endTime = System.currentTimeMillis(); // 종료 시간 측정
+		long duration = endTime - startTime; // 수행 시간 계산
+		log.info("CrawlingService finished in " + duration + " ms");
+
+		stockRepository.saveAll(new ArrayList<>(stocks.values()));
+		themaInfoRepository.saveAll(new ArrayList<>(themaInfos.values()));
+		themaRepository.saveAll(new ArrayList<>(themas.values()));
+
+		log.info("CrawlingService saved themas");
+	}
+}

--- a/search/src/main/resources/application.yaml
+++ b/search/src/main/resources/application.yaml
@@ -8,29 +8,38 @@ spring:
     password: timo
     url: jdbc:postgresql://localhost:5432/search_service
 
-
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
-        show_sql: true
+        format_sql: true
+#        use_sql_comments: true
+    show-sql: true
 
 redis:
-  address: redis://localhost:6379,redis://localhost:6381
+  address: redis://localhost:6379
   password: changeme
   database: 0
 
 mongodb:
   database: keywords
-  uri: mongodb://changeme:changeme@localhost:27017,mongodb://changeme:changeme@localhost:27018
-
+  uri: mongodb://changeme:changeme@localhost:27017
 
 logging:
   level:
-    com.bjcareer.search : debug
+#    org.hibernate.SQL: debug # SQL 쿼리 로그 출력
+    org.hibernate.orm.jdbc.bind: TRACE
 
-# 추가된 설정 항목
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      force: true
+      enabled: true
+
+
 database:
-  number: ${DATABASE_NUMBER:2}
+  number: 1
+  shardingKey: id

--- a/search/src/test/java/com/bjcareer/search/out/crawling/naver/CrawlingThemaTest.java
+++ b/search/src/test/java/com/bjcareer/search/out/crawling/naver/CrawlingThemaTest.java
@@ -1,0 +1,38 @@
+package com.bjcareer.search.out.crawling.naver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.bjcareer.search.domain.entity.Market;
+import com.bjcareer.search.domain.entity.Stock;
+
+class CrawlingThemaTest {
+
+	@Test
+	void test_extract_specific_stock() {
+		CrawlingThema mock = Mockito.mock(CrawlingThema.class);
+		Stock stock = new Stock("267790", "Barrel", Market.KOSDAQ,
+			"https://finance.naver.com/item/main.nhn?code=267790", 7888500L, 0L);
+
+		when(mock.getStock("267790", "Barrel")).thenReturn(stock);
+		Stock result = mock.getStock("267790", "Barrel");
+
+		verify(mock, times(1)).getStock("267790", "Barrel");
+	}
+
+	@Test
+	void test_invalid_information_provided()  {
+		CrawlingThema mock = Mockito.mock(CrawlingThema.class);
+		Stock stock = new Stock("2677901", "Barrel", null, null, null, null);
+
+		when(mock.getStock("2677901", "Barrel")).thenReturn(stock);
+		Stock result = mock.getStock("2677901", "Barrel");
+
+		assertEquals(false, result.validStock());
+	}
+}


### PR DESCRIPTION

# PR: 크롤링 서비스 성능 개선 및 가상 스레드 적용

## 변경 사항 개요
- **크롤링 스케줄 변경**: 크롤링 작업이 매일 **오후 4시 30분**에 자동 실행되도록 스케줄링 설정을 변경했습니다.
- **모든 데이터 불러오기 및 업데이트**: 크롤링 시 모든 데이터를 한 번에 불러오고, 크롤링 작업이 완료된 후 데이터 업데이트를 수행합니다.
- **가상 스레드 적용**: 크롤링 시간 단축을 위해 **가상 스레드**를 사용하여 병렬 처리를 최적화했습니다. 이를 통해 CPU 활용도를 높이고, 크롤링 작업의 성능을 향상시켰습니다.

## 상세 설명
1. **크롤링 스케줄 변경**
   - 기존에는 크롤링 작업이 매일 특정 시간이 아닌 수동으로 실행되었습니다. 이를 개선하여, 매일 오후 4시 30분에 크롤링 작업이 자동으로 실행되도록 `@Scheduled` 어노테이션을 사용해 스케줄링했습니다.

2. **모든 데이터 불러오기 및 업데이트**
   - 크롤링 작업을 통해 모든 데이터를 한 번에 불러온 후, 크롤링이 완료되면 기존 데이터를 일괄 업데이트합니다. 이를 통해 크롤링 중 데이터의 일관성을 유지하고, 중복 조회를 방지하였습니다.

3. **가상 스레드 적용**
   - 성능 최적화를 위해 가상 스레드를 도입하였습니다. 이를 통해 병렬 작업의 효율성을 극대화하고, 크롤링 시간을 단축시킬 수 있었습니다. 가상 스레드는 경량화된 스레드로, 다수의 작업을 동시에 처리할 수 있어 크롤링 서비스의 응답 시간을 개선할 수 있습니다.
